### PR TITLE
6.2.13 -> master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM		phusion/baseimage:0.9.18
 MAINTAINER	contact@oliver.la
-ENV		SEAFILE_VERSION 6.2.10
+ENV		SEAFILE_VERSION 6.2.12
 
 EXPOSE		8082 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM		phusion/baseimage:0.9.18
 MAINTAINER	contact@oliver.la
-ENV		SEAFILE_VERSION 6.2.12
+ENV		SEAFILE_VERSION 6.2.13
 
 EXPOSE		8082 8000
 


### PR DESCRIPTION
Changes in Docker image:

- Change version string in Dockerfile to 6.2.13.

Changes in Seafile Pro Edition: (source: https://manual.seafile.com/changelog/changelog-for-seafile-professional-server.html)

- [new] Support only return files or folders when search file via api.
- [fix] Fix notification display behavior bug on some page.
- [fix] Recreate folder when failed because of file already exists error for the first time.
- [fix] Fix bug of saving file via onlyoffice.
- [fix] Fix bug when set user’s reference id to ‘’ via admin api.
- [fix] Fix bug of group info page display in organization admin panel.
- [improve] Disable full email search if current user is a guest user.
- [improve] Return library type when search file via api.
- [improve] Add user auth info to cookie when login via OAuth.
- [improve] Return timestamp instead of time string when get user clean up library trash event via api.
- [improve] Check quota when copy/move file/folder.
- [improve] Distinguish file or folder when send library/folder share notice/email.
- [improve] Sort by parent folder’s name when get file/folder recursively.
- [improve] Remove unused Python imports in ADFS module.
- [improve] Optimizate library udpate event.
- [improve] Remove seahub gunicorn access log.