### PR TITLE
Upgrade to 6.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM		phusion/baseimage:0.9.18
 MAINTAINER	contact@oliver.la
-ENV		SEAFILE_VERSION 6.2.13
+ENV		SEAFILE_VERSION 6.3.2
 
 EXPOSE		8082 8000
 


### PR DESCRIPTION
This upgrade will skip 6.3.0 and 6.3.1 as they're both unavailable for download.

Changes in Docker image:

- Change version string in Dockerfile to 6.3.2.

Changes in Seafile Pro Edition: (source:
https://manual.seafile.com/changelog/changelog-for-seafile-professional-server.html)

- Support nested group and group-owned libraries
- Keep sharing link when file or folder moved or renamed
- Update Django to 1.11, remove fast-cgi support
- Update jQuery to version 3.3.1
- Update pdf.js, use pdf.js for preview pdf files
- Docx files are converted to PDFs and preview via pdf.js in builtin preview
- Support multiple storage backend to be used in a single server
- [fix] Fix some bugs with OnlyOffice and CollaboraOffice
- [fix] Use mobile version of OnlyOffice if viewed via mobile devices
- Shared sub-folders can be searched
- Show terms and condition link if terms and condition is enabled
- Remove login log after delete a user
- [admin] Support customize site title, site name, CSS via Web UI
- [fix] Fix a bug that causing seaf-fsck crash
- [fix] Cancel Zip download task at the server side when user close zip download dialog
- [fix] Fix crash when seaf-fsck, seaf-gc receive wrong arguments
- [fix] Fix a few bugs in realtime backup server
- [beta] Wiki, users can create public wikis
- Some other UI improvements
- Add generating of internal links
- Lock office files when editing via online office suite
- Support setting organization quota, delete an organization via Web API
- Support Swift storage backend Identity v3.0 API
- Improve markdown editor
- Several fixes
- [fix] Fix sometimes get group listing will cause ccnet-server crash
- [fix] Fix built in office file preview can't works
- Redirect '/shib-login' to '/sso'
- Other small fixes