### PR TITLE
Upgrade to 6.3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM		phusion/baseimage:0.9.18
 MAINTAINER	contact@oliver.la
-ENV		SEAFILE_VERSION 6.3.2
+ENV		SEAFILE_VERSION 6.3.4
 
 EXPOSE		8082 8000
 


### PR DESCRIPTION
Changes in Docker image:

- Change version string in Dockerfile to 6.3.4.

Changes in Seafile Pro Edition: (source:
https://manual.seafile.com/changelog/changelog-for-seafile-professional-server.html)

- [fix] Fix a bug in creating group-owned library