### PR TITLE
Upgrade to 6.3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM		phusion/baseimage:0.9.18
 MAINTAINER	contact@oliver.la
-ENV		SEAFILE_VERSION 6.3.2
+ENV		SEAFILE_VERSION 6.3.6
 
 EXPOSE		8082 8000
 


### PR DESCRIPTION
This upgrade will skip 6.3.5 as it's unavailable for download.

Changes in Docker image:

- Change version string in Dockerfile to 6.3.6.

Changes in Seafile Pro Edition: (source:
https://manual.seafile.com/changelog/changelog-for-seafile-professional-server.html)

- [fix, security] Fix a security issue in Shibboleth authentication
- [fix] Fix sometimes Web UI will not autoload a >100 item directory view
- [fix] Fix sending notification emails in backend node
- Showing user's name instead of email in web interface
- [fix] Fix desktop client can't login if using ADFS
- Add a new sharing link permission "can edit" for docx/excel. Any login users can edit the file via share link.
- [multi-tenancy] Support department and department owned library
- Add system traffic statistics (showing the daily web download/web upload/sync traffic)
- [fix] Fix a bug in user defined role
- [fix] Editable share link can be edited by anonymous user