### PR TITLE
Upgrade to 6.3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM		phusion/baseimage:0.9.18
 MAINTAINER	contact@oliver.la
-ENV		SEAFILE_VERSION 6.3.2
+ENV		SEAFILE_VERSION 6.3.7
 
 EXPOSE		8082 8000
 


### PR DESCRIPTION
Changes in Docker image:

Change version string in Dockerfile to 6.3.7.

Changes in Seafile Pro Edition: (source:
https://manual.seafile.com/changelog/changelog-for-seafile-professional-server.html)

- [fix] Fix a bug of lock by online office
- Anyone that can write a file can unlock the file if it is locked by online office
- [fix] Fix a bug in sending mails in background node
- [fix] Remove forcesave option in OnlyOffice since it have a bug
- [fix] Fix a bug that wiki page can't be loaded
- Add traffic statistics
- [fix] Remove unnecessary logs in virus scan